### PR TITLE
Classe OwnedException e ZipCodeException que herda da anterior.

### DIFF
--- a/solutions/devsprint-michel-ferreira-1/src/main/kotlin/com/devpass/challengehexagonal/resources/exceptions/OwnedException.kt
+++ b/solutions/devsprint-michel-ferreira-1/src/main/kotlin/com/devpass/challengehexagonal/resources/exceptions/OwnedException.kt
@@ -1,0 +1,3 @@
+package com.devpass.challengehexagonal.resources.exceptions
+
+open class OwnedException(message: String) : Exception(message)

--- a/solutions/devsprint-michel-ferreira-1/src/main/kotlin/com/devpass/challengehexagonal/resources/exceptions/ZipCodeException.kt
+++ b/solutions/devsprint-michel-ferreira-1/src/main/kotlin/com/devpass/challengehexagonal/resources/exceptions/ZipCodeException.kt
@@ -1,0 +1,3 @@
+package com.devpass.challengehexagonal.resources.exceptions
+
+class ZipCodeException(message: String) : OwnedException(message)


### PR DESCRIPTION
## O que é

Criação de uma exceção na qual deve herdar de Exception para tratar erros específicos.

## Critérios de aceitação:

- [x]  Exception ZipCodeNotFoundException criada

Obs: No modelo da sprint anterior, criei uma open class chamada OwnedException para que as demais classes de exceção herdem dela.