### PR TITLE
[KT3-08] Criar objeto de domínio credit card invoice e função de-para em CreditCardInvoiceEntity

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/data/entities/CreditCardInvoiceEntity.kt
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/data/entities/CreditCardInvoiceEntity.kt
@@ -18,13 +18,13 @@ data class CreditCardInvoiceEntity(
 ) {
     fun toCreditCardInvoice(): CreditCardInvoice {
         return CreditCardInvoice(
-            id = this.id,
-            creditCard = this.creditCard,
-            month = this.month,
-            year = this.year,
-            value = this.value,
-            createdAt = this.createdAt,
-            paidAt = this.paidAt
+            this.id,
+            this.creditCard,
+            this.month,
+            this.year,
+            this.value,
+            this.createdAt,
+            this.paidAt
         )
     }
 }

--- a/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/data/entities/CreditCardInvoiceEntity.kt
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/data/entities/CreditCardInvoiceEntity.kt
@@ -1,5 +1,6 @@
 package io.devpass.creditcard.data.entities
 
+import io.devpass.creditcard.domain.objects.CreditCardInvoice
 import org.hibernate.annotations.CreationTimestamp
 import java.time.LocalDateTime
 import javax.persistence.Id
@@ -14,4 +15,16 @@ data class CreditCardInvoiceEntity(
     @CreationTimestamp
     var createdAt: LocalDateTime = LocalDateTime.now(),
     var paidAt: LocalDateTime? = LocalDateTime.now()
-)
+) {
+    fun toCreditCardInvoice(): CreditCardInvoice {
+        return CreditCardInvoice(
+            id = this.id,
+            creditCard = this.creditCard,
+            month = this.month,
+            year = this.year,
+            value = this.value,
+            createdAt = this.createdAt,
+            paidAt = this.paidAt
+        )
+    }
+}

--- a/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/domain/objects/CreditCardInvoice.kt
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/domain/objects/CreditCardInvoice.kt
@@ -1,0 +1,13 @@
+package io.devpass.creditcard.domain.objects
+
+import java.time.LocalDateTime
+
+data class CreditCardInvoice(
+    var id: String,
+    var creditCard: String,
+    var month: Int,
+    var year: Int,
+    var value: Double,
+    var createdAt: LocalDateTime,
+    var paidAt: LocalDateTime?
+) 


### PR DESCRIPTION
## O que é

Na arquitetura hexagonal, o domínio não conhece diretamente a entity, mas sim um objeto de domínio. Crie o objeto de domínio `CreditCardInvoice` no package `domain/objects`, assim como uma função na `CreditCardInvoiceEntity` para gerar um objeto de domínio.

**Importante: o objeto de domínio geralmente é idêntico ao objeto da sua fonte, porém, para respeitar a arquitetura, precisamos criar esse objeto 100% desvinculado de sua fonte, que não é conhecida pelo domínio da aplicação.** 

## Critérios de aceite

- [x]  Objeto de domínio criado no package adequado
- [x]  Função de `de-para` criada na classe adequada
- [x]  Objeto de domínio criado é um classe (embora leve o nome de objeto)

