### PR TITLE
[KT3-07] Criar objeto de domínio credit card operation e função de-para em CreditCardOperationEntity

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/data/entities/CreditCardOperationEntity.kt
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/data/entities/CreditCardOperationEntity.kt
@@ -1,5 +1,6 @@
 package io.devpass.creditcard.data.entities
 
+import io.devpass.creditcard.domain.objects.CreditCardOperation
 import org.hibernate.annotations.CreationTimestamp
 import java.time.LocalDateTime
 import javax.persistence.Entity
@@ -15,4 +16,15 @@ data class CreditCardOperationEntity(
     var description: String,
     @CreationTimestamp
     var createdAt: LocalDateTime = LocalDateTime.now(),
-)
+) {
+    fun toCreditCardOperation(): CreditCardOperation {
+        return CreditCardOperation(
+            this.id,
+            this.credit_card,
+            this.type,
+            this.value,
+            this.description,
+            this.createdAt
+        )
+    }
+}

--- a/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/domain/objects/CreditCardOperation.kt
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/domain/objects/CreditCardOperation.kt
@@ -1,0 +1,12 @@
+package io.devpass.creditcard.domain.objects
+
+import java.time.LocalDateTime
+
+data class CreditCardOperation(
+        var id: String,
+        var credit_card: String,
+        var type: String,
+        var value: Double,
+        var description: String,
+        var createdAt: LocalDateTime?,
+)


### PR DESCRIPTION
## Critérios de aceite

- [ ]  Objeto de domínio criado no package adequado
- [ ]  Função de `de-para` criada na classe adequada
- [ ]  Objeto de domínio criado é um classe (embora leve o nome de objeto)