### PR TITLE
[KT3-11] Criar ICreditCardInvoiceDAO, implementar interface, e registrar criação em BeanGenerator

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/data/CreditCardInvoiceDAO.kt
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/data/CreditCardInvoiceDAO.kt
@@ -1,0 +1,17 @@
+package io.devpass.creditcard.data
+
+
+import io.devpass.creditcard.data.repositories.CreditCardInvoiceRepository
+import io.devpass.creditcard.dataaccess.ICreditCardInvoiceDAO
+import io.devpass.creditcard.domain.objects.CreditCardInvoice
+import io.devpass.creditcard.domain.objects.CreditCardOperation
+
+class CreditCardInvoiceDAO(
+    private val creditCardInvoiceRepository: CreditCardInvoiceRepository,
+) : ICreditCardInvoiceDAO {
+    override fun getById(id: String): CreditCardInvoice? {
+        val creditCardInvoiceEntity = creditCardInvoiceRepository.findById(id)
+        return if (creditCardInvoiceEntity.isPresent) creditCardInvoiceEntity.get()
+            .toCreditCardInvoice() else null
+    }
+}

--- a/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/dataaccess/ICreditCardInvoiceDAO.kt
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/dataaccess/ICreditCardInvoiceDAO.kt
@@ -1,0 +1,7 @@
+package io.devpass.creditcard.dataaccess
+
+import io.devpass.creditcard.domain.objects.CreditCardInvoice
+
+interface ICreditCardInvoiceDAO {
+    fun getById(id: String): CreditCardInvoice?
+}

--- a/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/domain/CreditCardInvoiceService.kt
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/domain/CreditCardInvoiceService.kt
@@ -1,0 +1,13 @@
+package io.devpass.creditcard.domain
+
+import io.devpass.creditcard.dataaccess.ICreditCardInvoiceDAO
+import io.devpass.creditcard.domain.objects.CreditCardInvoice
+import io.devpass.creditcard.domainaccess.ICreditCardInvoiceServiceAdapter
+
+class CreditCardInvoiceService (
+    private val creditCardInvoiceDAO: ICreditCardInvoiceDAO,
+) : ICreditCardInvoiceServiceAdapter {
+    override fun getById(creditCardInvoiceId: String): CreditCardInvoice? {
+        return creditCardInvoiceDAO.getById(creditCardInvoiceId)
+    }
+}

--- a/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/domainaccess/ICreditCardInvoiceServiceAdapter.kt
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/domainaccess/ICreditCardInvoiceServiceAdapter.kt
@@ -1,0 +1,7 @@
+package io.devpass.creditcard.domainaccess
+
+import io.devpass.creditcard.domain.objects.CreditCardInvoice
+
+interface ICreditCardInvoiceServiceAdapter {
+    fun getById(creditCardInvoiceId: String): CreditCardInvoice?
+}

--- a/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/infrastructure/BeanGenerator.kt
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/infrastructure/BeanGenerator.kt
@@ -1,13 +1,18 @@
 package io.devpass.creditcard.infrastructure
 
 import io.devpass.creditcard.data.CreditCardDAO
+import io.devpass.creditcard.data.CreditCardInvoiceDAO
 import io.devpass.creditcard.data.repositories.CreditCardRepository
 import io.devpass.creditcard.data.CreditCardOperationDAO
+import io.devpass.creditcard.data.repositories.CreditCardInvoiceRepository
 import io.devpass.creditcard.data.repositories.CreditCardOperationRepository
 import io.devpass.creditcard.dataaccess.ICreditCardDAO
+import io.devpass.creditcard.dataaccess.ICreditCardInvoiceDAO
 import io.devpass.creditcard.dataaccess.ICreditCardOperationDAO
+import io.devpass.creditcard.domain.CreditCardInvoiceService
 import io.devpass.creditcard.domain.CreditCardOperationService
 import io.devpass.creditcard.domain.CreditCardService
+import io.devpass.creditcard.domainaccess.ICreditCardInvoiceServiceAdapter
 import io.devpass.creditcard.domainaccess.ICreditCardOperationServiceAdapter
 import io.devpass.creditcard.domainaccess.ICreditCardServiceAdapter
 import org.springframework.context.annotation.Bean
@@ -40,5 +45,17 @@ class BeanGenerator {
         creditCardOperationDAO: ICreditCardOperationDAO,
     ): ICreditCardOperationServiceAdapter {
         return CreditCardOperationService(creditCardOperationDAO)
+    }
+
+    @Bean
+    fun creditCardInvoiceDAO(creditCardInvoiceRepository: CreditCardInvoiceRepository): ICreditCardInvoiceDAO {
+        return CreditCardInvoiceDAO(creditCardInvoiceRepository)
+    }
+
+    @Bean
+    fun creditCardInvoiceServiceAdapter(
+        creditCardInvoiceDAO: ICreditCardInvoiceDAO,
+    ): ICreditCardInvoiceServiceAdapter {
+        return CreditCardInvoiceService(creditCardInvoiceDAO)
     }
 }

--- a/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/transport/controllers/CreditCardInvoiceController.kt
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/transport/controllers/CreditCardInvoiceController.kt
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("creditCardInvoice")
+@RequestMapping("credit-card-invoices")
 class CreditCardInvoiceController(
     private val creditCardInvoiceServiceAdapter: ICreditCardInvoiceServiceAdapter
 ) {

--- a/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/transport/controllers/CreditCardInvoiceController.kt
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/transport/controllers/CreditCardInvoiceController.kt
@@ -1,0 +1,21 @@
+package io.devpass.creditcard.transport.controllers
+
+import io.devpass.creditcard.domain.exceptions.OwnedException
+import io.devpass.creditcard.domain.objects.CreditCardInvoice
+import io.devpass.creditcard.domainaccess.ICreditCardInvoiceServiceAdapter
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("creditCardInvoice")
+class CreditCardInvoiceController(
+    private val creditCardInvoiceServiceAdapter: ICreditCardInvoiceServiceAdapter
+) {
+    @GetMapping("/{creditCardInvoiceId}")
+    fun getById(@PathVariable creditCardInvoiceId: String): CreditCardInvoice {
+        return creditCardInvoiceServiceAdapter.getById(creditCardInvoiceId)
+            ?: throw OwnedException("Credit Card Invoice Not found with ID: $creditCardInvoiceId")
+    }
+}


### PR DESCRIPTION
## O que é

Na arquitetura hexagonal, o domínio se comunica com fontes de dados por meio de uma interface, sem ter conhecimento algum sobre a verdadeira fonte da informação. Crie a interface `ICreditCardInvoiceDAO` no package `dataaccess`, e uma implementação dela no package `data`.

**Importante: você deve criar uma classe chamada CreditCardInvoiceDAO, que implemente ICreditCardInvoiceDAO, e não a interface CreditCardInvoiceRepository utilizada para comunicação com o banco de dados.**

Lembre-se também de registrar na classe infrastructure/BeanGenerator a criação do seu repository.

## Critérios de aceite

- [ ]  Classes criadas em packages adequados
- [ ]  Classes implementam interfaces adequadas
- [ ]  Bean de criação da interface registrado em `infrastructure/BeanGenerator`