### PR TITLE
[KT3-16] Implementa consulta de conta por ID no IAccountManagerGateway

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/data/AccountManagementGateway.kt
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/data/AccountManagementGateway.kt
@@ -22,4 +22,14 @@ class AccountManagementGateway(
             throw GatewayException("Erro na busca da conta pelo CPF: $CPF")
         }
     }
+    override fun getAccountById(accountId: String) : Account {
+        val (_, result, response) = Fuel
+                .get("$baseUrl/account-management/balance/$accountId")
+                .responseObject<AccountResponse>(jacksonDeserializerOf())
+        return if (result.isSuccessful) {
+            response.get().toAccount()
+        } else {
+            throw GatewayException("Erro na busca da conta pelo ID: $accountId")
+        }
+    }
 }

--- a/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/dataaccess/IAccountManagementGateway.kt
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/dataaccess/IAccountManagementGateway.kt
@@ -1,7 +1,8 @@
 package io.devpass.creditcard.dataaccess
-
 import io.devpass.creditcard.domain.objects.accountmanagement.Account
 
 interface IAccountManagementGateway {
     fun getByCPF(CPF: String): Account
+
+    fun getAccountById(accountId : String) : Account
 }


### PR DESCRIPTION
## O que é

Para realizar o pagamento da fatura, precisamos consultar a conta do dono do cartão. Complemente a interface `IAccountManagerGateway` com uma função para consultar uma conta por ID de conta.

## Critérios de aceite

- [ ]  Arquivos criados nos packages adequados
- [ ]  Implementação executa uma chamada HTTP para se comunicar com o service de account-management