### PR TITLE
[KT3-25] Complementar CreditCardOperation com campo indicando mês e ano em que a operação aconteceu

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/data/entities/CreditCardOperationEntity.kt
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/data/entities/CreditCardOperationEntity.kt
@@ -14,6 +14,8 @@ data class CreditCardOperationEntity(
     var type: String,
     var value: Double,
     var description: String,
+    var month: Int,
+    var year: Int,
     @CreationTimestamp
     var createdAt: LocalDateTime = LocalDateTime.now(),
 ) {
@@ -24,6 +26,8 @@ data class CreditCardOperationEntity(
             this.type,
             this.value,
             this.description,
+            this.month,
+            this.year,
             this.createdAt
         )
     }

--- a/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/domain/objects/CreditCardOperation.kt
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/domain/objects/CreditCardOperation.kt
@@ -8,5 +8,7 @@ data class CreditCardOperation(
     var type: String,
     var value: Double,
     var description: String,
+    var month: Int,
+    var year: Int,
     var createdAt: LocalDateTime = LocalDateTime.now(),
 )

--- a/solutions/devsprint-luiz-zytkowski-3/src/main/resources/db/migrations/V4__alter_table_credit_card_operation.sql
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/resources/db/migrations/V4__alter_table_credit_card_operation.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `credit_card_operation`
+    ADD `month` INT NOT NULL,
+    ADD `year`INT NOT NULL;


### PR DESCRIPTION
## O que é

Complemente a *entity* e o *domain object* de CreditCardOperation para conter dois novos campos indicando mês e ano da operação.

1. Crie uma `migration` para adicionar os novos campos na tabela.
2. Atualize a `entity`com os novos campos.
3. Atualize o `domain object` com os novos campos.

Observação

O `README.md` tem a descrição dos novos campos.

## Critérios de aceite

- [ ]  Migration executa corretamente ao subir o sistema.
- [ ]  Campos com tipos adequados.