### PR TITLE
[KT3-24] Implementar fechamento de fatura de cartão

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/data/CreditCardInvoiceDAO.kt
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/data/CreditCardInvoiceDAO.kt
@@ -4,7 +4,6 @@ package io.devpass.creditcard.data
 import io.devpass.creditcard.data.repositories.CreditCardInvoiceRepository
 import io.devpass.creditcard.dataaccess.ICreditCardInvoiceDAO
 import io.devpass.creditcard.domain.objects.CreditCardInvoice
-import io.devpass.creditcard.domain.objects.CreditCardOperation
 
 class CreditCardInvoiceDAO(
     private val creditCardInvoiceRepository: CreditCardInvoiceRepository,
@@ -13,5 +12,9 @@ class CreditCardInvoiceDAO(
         val creditCardInvoiceEntity = creditCardInvoiceRepository.findById(id)
         return if (creditCardInvoiceEntity.isPresent) creditCardInvoiceEntity.get()
             .toCreditCardInvoice() else null
+    }
+
+    override fun generateCreditCardInvoice(creditCardId: String, invoiceMonth: Int, invoiceYear: Int): CreditCardInvoice {
+        return creditCardInvoiceRepository.getInvoice(creditCardId, invoiceMonth, invoiceYear)
     }
 }

--- a/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/data/CreditCardInvoiceDAO.kt
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/data/CreditCardInvoiceDAO.kt
@@ -1,13 +1,18 @@
 package io.devpass.creditcard.data
 
 
+import io.devpass.creditcard.data.entities.CreditCardInvoiceEntity
 import io.devpass.creditcard.data.repositories.CreditCardInvoiceRepository
+import io.devpass.creditcard.data.repositories.CreditCardOperationRepository
 import io.devpass.creditcard.dataaccess.ICreditCardInvoiceDAO
 import io.devpass.creditcard.domain.objects.CreditCardInvoice
 import io.devpass.creditcard.domain.objects.CreditCardInvoiceByDate
+import java.time.LocalDateTime
+import java.util.UUID
 
 class CreditCardInvoiceDAO(
     private val creditCardInvoiceRepository: CreditCardInvoiceRepository,
+    private val creditCardOperationRepository: CreditCardOperationRepository
 ) : ICreditCardInvoiceDAO {
     override fun getById(id: String): CreditCardInvoice? {
         val creditCardInvoiceEntity = creditCardInvoiceRepository.findById(id)
@@ -24,7 +29,30 @@ class CreditCardInvoiceDAO(
 
     }
 
-    override fun generateCreditCardInvoice(creditCardId: String, invoiceMonth: Int, invoiceYear: Int): CreditCardInvoice {
-        return creditCardInvoiceRepository.getInvoice(creditCardId, invoiceMonth, invoiceYear)
+    override fun generateCreditCardInvoice(creditCardId: String): CreditCardInvoice {
+        val listOfCreditCardOperation =
+            creditCardOperationRepository.listByPeriod(
+                creditCardId,
+                LocalDateTime.now().monthValue,
+                LocalDateTime.now().year
+            ).filter {
+                it.type == "Cobrança" || it.type == "Estorno"
+            }.map { it.toCreditCardOperation() }
+
+        val invoiceValue = listOfCreditCardOperation.sumOf {
+            it.value
+        }
+
+        return creditCardInvoiceRepository.save<CreditCardInvoiceEntity?>(
+            CreditCardInvoiceEntity(
+                id = UUID.randomUUID().toString(),
+                creditCard = creditCardId,
+                month = LocalDateTime.now().monthValue,
+                year = LocalDateTime.now().year,
+                value = invoiceValue,
+                createdAt = LocalDateTime.now(),
+                paidAt = null
+            )
+        ).toCreditCardInvoice()
     }
 }

--- a/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/data/CreditCardOperationDAO.kt
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/data/CreditCardOperationDAO.kt
@@ -9,7 +9,7 @@ import java.util.UUID
 class CreditCardOperationDAO(
     private val creditCardOperationRepository: CreditCardOperationRepository,
 ) : ICreditCardOperationDAO {
-  
+
     override fun getById(id: String): CreditCardOperation? {
         val creditCardOperationEntity = creditCardOperationRepository.findById(id)
         return if (creditCardOperationEntity.isPresent) creditCardOperationEntity.get()

--- a/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/data/repositories/CreditCardInvoiceRepository.kt
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/data/repositories/CreditCardInvoiceRepository.kt
@@ -1,7 +1,6 @@
 package io.devpass.creditcard.data.repositories
 
 import io.devpass.creditcard.data.entities.CreditCardInvoiceEntity
-import io.devpass.creditcard.domain.objects.CreditCardInvoice
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
@@ -9,9 +8,6 @@ import org.springframework.stereotype.Repository
 @Repository
 interface CreditCardInvoiceRepository : CrudRepository<CreditCardInvoiceEntity, String> {
 
-    @Query("SELECT ccie FROM CreditCardInvoiceEntity ccie WHERE ccie.id = ?1 AND ccie.month = ?2 AND ccie.year = ?3")
-    fun getInvoice(creditCardId: String, invoiceMonth: Int, invoiceYear: Int): CreditCardInvoice
-
-    @Query("select ccie from CreditCardInvoiceEntity ccie where ccie.credit_card = ?1 and ccie.month = ?2 and ccie.year = ?3")
+    @Query("select ccie from CreditCardInvoiceEntity ccie where ccie.creditCard = ?1 and ccie.month = ?2 and ccie.year = ?3")
     fun findByInvoiceByDate(creditCard: String, month: Int, year: Int): List<CreditCardInvoiceEntity>
 }

--- a/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/data/repositories/CreditCardInvoiceRepository.kt
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/data/repositories/CreditCardInvoiceRepository.kt
@@ -1,10 +1,14 @@
 package io.devpass.creditcard.data.repositories
 
 import io.devpass.creditcard.data.entities.CreditCardInvoiceEntity
+import io.devpass.creditcard.domain.objects.CreditCardInvoice
+import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
 
 @Repository
 interface CreditCardInvoiceRepository : CrudRepository<CreditCardInvoiceEntity, String> {
 
+    @Query("SELECT ccie FROM CreditCardInvoiceEntity ccie WHERE ccie.id = ?1 AND ccie.month = ?2 AND ccie.year = ?3")
+    fun getInvoice(creditCardId: String, invoiceMonth: Int, invoiceYear: Int): CreditCardInvoice
 }

--- a/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/data/repositories/CreditCardOperationRepository.kt
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/data/repositories/CreditCardOperationRepository.kt
@@ -8,5 +8,4 @@ interface CreditCardOperationRepository : CrudRepository<CreditCardOperationEnti
 
     @Query("SELECT ccoe FROM CreditCardOperationEntity ccoe WHERE ccoe.id = ?1 AND ccoe.month = ?2 AND ccoe.year = ?3")
     fun listByPeriod(creditCardId: String, month: Int, year: Int): List<CreditCardOperationEntity>
-
 }

--- a/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/dataaccess/ICreditCardInvoiceDAO.kt
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/dataaccess/ICreditCardInvoiceDAO.kt
@@ -4,4 +4,6 @@ import io.devpass.creditcard.domain.objects.CreditCardInvoice
 
 interface ICreditCardInvoiceDAO {
     fun getById(id: String): CreditCardInvoice?
+
+    fun generateCreditCardInvoice(creditCardId: String, invoiceMonth: Int, invoiceYear: Int) : CreditCardInvoice
 }

--- a/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/dataaccess/ICreditCardInvoiceDAO.kt
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/dataaccess/ICreditCardInvoiceDAO.kt
@@ -6,7 +6,7 @@ import io.devpass.creditcard.domain.objects.CreditCardInvoiceByDate
 interface ICreditCardInvoiceDAO {
     fun getById(id: String): CreditCardInvoice?
 
-    fun generateCreditCardInvoice(creditCardId: String, invoiceMonth: Int, invoiceYear: Int) : CreditCardInvoice
-
     fun findInvoiceByDate(creditCardInvoiceByDate: CreditCardInvoiceByDate): CreditCardInvoice?
+
+    fun generateCreditCardInvoice(creditCardId: String) : CreditCardInvoice
 }

--- a/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/domain/CreditCardInvoiceService.kt
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/domain/CreditCardInvoiceService.kt
@@ -1,7 +1,6 @@
 package io.devpass.creditcard.domain
 
 import io.devpass.creditcard.dataaccess.ICreditCardInvoiceDAO
-import io.devpass.creditcard.domain.exceptions.BusinessRuleException
 import io.devpass.creditcard.domain.exceptions.OwnedException
 import io.devpass.creditcard.domain.objects.CreditCardInvoice
 import io.devpass.creditcard.domain.objects.CreditCardInvoiceByDate
@@ -14,25 +13,6 @@ class CreditCardInvoiceService(
 ) : ICreditCardInvoiceServiceAdapter {
     override fun getById(creditCardInvoiceId: String): CreditCardInvoice? {
         return creditCardInvoiceDAO.getById(creditCardInvoiceId)
-    }
-
-    override fun generateCreditCardInvoice(
-        creditCardId: String,
-        invoiceMonth: Int,
-        invoiceYear: Int
-    ): CreditCardInvoice {
-        creditCardInvoiceDAO.getById(creditCardId)
-            ?: throw EntityNotFoundException("Cartão de id: $creditCardId não encontrado")
-
-        if (invoiceMonth !in 1..12) {
-            throw BusinessRuleException("Mês inserido inválido")
-        }
-
-        if (invoiceYear < 1950) {
-            throw BusinessRuleException("Ano inserido inválido")
-        }
-
-        return creditCardInvoiceDAO.generateCreditCardInvoice(creditCardId, invoiceMonth, invoiceYear)
     }
 
     override fun findInvoiceByDate(creditCardInvoiceByDate: CreditCardInvoiceByDate): CreditCardInvoice? {
@@ -48,5 +28,14 @@ class CreditCardInvoiceService(
         }
 
         return creditCardInvoiceDAO.findInvoiceByDate(creditCardInvoiceByDate)
+    }
+
+    override fun generateCreditCardInvoice(
+        creditCardId: String,
+    ): CreditCardInvoice {
+        creditCardInvoiceDAO.getById(creditCardId)
+            ?: throw EntityNotFoundException("Cartão de id: $creditCardId não encontrado")
+
+        return creditCardInvoiceDAO.generateCreditCardInvoice(creditCardId)
     }
 }

--- a/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/domain/CreditCardInvoiceService.kt
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/domain/CreditCardInvoiceService.kt
@@ -1,13 +1,34 @@
 package io.devpass.creditcard.domain
 
 import io.devpass.creditcard.dataaccess.ICreditCardInvoiceDAO
+import io.devpass.creditcard.domain.exceptions.BusinessRuleException
 import io.devpass.creditcard.domain.objects.CreditCardInvoice
 import io.devpass.creditcard.domainaccess.ICreditCardInvoiceServiceAdapter
+import javax.persistence.EntityNotFoundException
 
 class CreditCardInvoiceService (
     private val creditCardInvoiceDAO: ICreditCardInvoiceDAO,
 ) : ICreditCardInvoiceServiceAdapter {
     override fun getById(creditCardInvoiceId: String): CreditCardInvoice? {
         return creditCardInvoiceDAO.getById(creditCardInvoiceId)
+    }
+
+    override fun generateCreditCardInvoice(
+        creditCardId: String,
+        invoiceMonth: Int,
+        invoiceYear: Int
+    ): CreditCardInvoice {
+        creditCardInvoiceDAO.getById(creditCardId)
+            ?: throw EntityNotFoundException("Cartão de id: $creditCardId não encontrado")
+
+        if (invoiceMonth !in 1..12) {
+            throw BusinessRuleException("Mês inserido inválido")
+        }
+
+        if (invoiceYear < 1950) {
+            throw BusinessRuleException("Ano inserido inválido")
+        }
+
+        return creditCardInvoiceDAO.generateCreditCardInvoice(creditCardId, invoiceMonth, invoiceYear)
     }
 }

--- a/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/domain/exceptions/BusinessRuleException.kt
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/domain/exceptions/BusinessRuleException.kt
@@ -1,0 +1,3 @@
+package io.devpass.creditcard.domain.exceptions
+
+open class BusinessRuleException(message: String) : Exception(message)

--- a/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/domainaccess/ICreditCardInvoiceServiceAdapter.kt
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/domainaccess/ICreditCardInvoiceServiceAdapter.kt
@@ -6,7 +6,7 @@ import io.devpass.creditcard.domain.objects.CreditCardInvoiceByDate
 interface ICreditCardInvoiceServiceAdapter {
     fun getById(creditCardInvoiceId: String): CreditCardInvoice?
 
-    fun generateCreditCardInvoice(creditCardId: String, invoiceMonth: Int, invoiceYear: Int) : CreditCardInvoice
-
     fun findInvoiceByDate(creditCardInvoiceByDate: CreditCardInvoiceByDate): CreditCardInvoice?
+
+    fun generateCreditCardInvoice(creditCardId: String) : CreditCardInvoice
 }

--- a/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/domainaccess/ICreditCardInvoiceServiceAdapter.kt
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/domainaccess/ICreditCardInvoiceServiceAdapter.kt
@@ -4,4 +4,6 @@ import io.devpass.creditcard.domain.objects.CreditCardInvoice
 
 interface ICreditCardInvoiceServiceAdapter {
     fun getById(creditCardInvoiceId: String): CreditCardInvoice?
+
+    fun generateCreditCardInvoice(creditCardId: String, invoiceMonth: Int, invoiceYear: Int) : CreditCardInvoice
 }

--- a/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/infrastructure/BeanGenerator.kt
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/infrastructure/BeanGenerator.kt
@@ -54,8 +54,11 @@ class BeanGenerator {
     }
 
     @Bean
-    fun creditCardInvoiceDAO(creditCardInvoiceRepository: CreditCardInvoiceRepository): ICreditCardInvoiceDAO {
-        return CreditCardInvoiceDAO(creditCardInvoiceRepository)
+    fun creditCardInvoiceDAO(
+        creditCardInvoiceRepository: CreditCardInvoiceRepository,
+        creditCardOperationRepository: CreditCardOperationRepository
+    ): ICreditCardInvoiceDAO {
+        return CreditCardInvoiceDAO(creditCardInvoiceRepository, creditCardOperationRepository)
     }
 
     @Bean

--- a/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/transport/controllers/CreditCardInvoiceController.kt
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/transport/controllers/CreditCardInvoiceController.kt
@@ -5,6 +5,7 @@ import io.devpass.creditcard.domain.objects.CreditCardInvoice
 import io.devpass.creditcard.domainaccess.ICreditCardInvoiceServiceAdapter
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -20,12 +21,10 @@ class CreditCardInvoiceController(
             ?: throw OwnedException("Credit Card Invoice Not found with ID: $creditCardInvoiceId")
     }
 
-    @GetMapping("/")
+    @PostMapping
     fun generateCreditCardInvoice(
-        @RequestParam creditCardId: String,
-        invoiceMonth: Int,
-        invoiceYear: Int
+        @RequestParam creditCardId: String
     ): CreditCardInvoice {
-        return creditCardInvoiceServiceAdapter.generateCreditCardInvoice(creditCardId, invoiceMonth, invoiceYear)
+        return creditCardInvoiceServiceAdapter.generateCreditCardInvoice(creditCardId)
     }
 }

--- a/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/transport/controllers/CreditCardInvoiceController.kt
+++ b/solutions/devsprint-luiz-zytkowski-3/src/main/kotlin/io/devpass/creditcard/transport/controllers/CreditCardInvoiceController.kt
@@ -6,6 +6,7 @@ import io.devpass.creditcard.domainaccess.ICreditCardInvoiceServiceAdapter
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -17,5 +18,14 @@ class CreditCardInvoiceController(
     fun getById(@PathVariable creditCardInvoiceId: String): CreditCardInvoice {
         return creditCardInvoiceServiceAdapter.getById(creditCardInvoiceId)
             ?: throw OwnedException("Credit Card Invoice Not found with ID: $creditCardInvoiceId")
+    }
+
+    @GetMapping("/")
+    fun generateCreditCardInvoice(
+        @RequestParam creditCardId: String,
+        invoiceMonth: Int,
+        invoiceYear: Int
+    ): CreditCardInvoice {
+        return creditCardInvoiceServiceAdapter.generateCreditCardInvoice(creditCardId, invoiceMonth, invoiceYear)
     }
 }


### PR DESCRIPTION
## O que é

Implemente um endpoint para fechar a fatura de um cartão.

1. Crie a interface `ICreditCardInvoiceServiceAdapter` (caso não exista) no package `domainaccess`, com o método `generateCreditCardInvoice`
2. Implemente a interface dentro do package `data`, e registre a criação da classe no `BeanGenerator`.
3. Crie `CreditCardInvoiceController` (caso não exista) dentro do package transport, ele deve pedir um `ICreditCardInvoiceServiceAdapter` como parâmetro de construtor.
4. Implemente o endpoint que chama essa função no `CreditCardInvoiceController`.

### Regras de negócio:

- Você deve receber um ID de cartão, mês, e ano para fazer o fechamento da fatura.
- Você deve validar se o cartão existe.
- Você deve validar se o mês/ano informado são válidos.
- Somente pode existir uma fatura por mês/ano/cartão. Ou seja, deve-se levantar um erro caso tente fechar uma fatura de um mês que já está fechado.

Lembre-se: o código dentro de `transport` pode referenciar objetos dentro de `domain`, seu objeto de criação de cartão é um exemplo disso.

**Você é responsável por implementar todo o código dessa feature, desde o controller até queries caso sejam necessárias.**

## Critérios de aceite

- [ ]  Regras de negócio respeitadas.
- [ ]  O processo levanta erros relevantes que herdam de OwnedException.
- [ ]  Arquitetura respeitada.